### PR TITLE
Cosmetics fix for Validate() to be specified on struct instead of pointer

### DIFF
--- a/checkers/assigned_address/spec.go
+++ b/checkers/assigned_address/spec.go
@@ -10,8 +10,8 @@ type spec struct {
 	IPv4      string  `json:"ipv4"`
 }
 
-func (s *spec) Validate() error {
-	return validation.ValidateStruct(s,
+func (s spec) Validate() error {
+	return validation.ValidateStruct(&s,
 		validation.Field(&s.IPv4, validation.Required, is.IPv4),
 	)
 }

--- a/checkers/dns_lookup/spec.go
+++ b/checkers/dns_lookup/spec.go
@@ -15,8 +15,8 @@ type spec struct {
 	Timeout  config.Duration `json:"timeout"`
 }
 
-func (s *spec) Validate() error {
-	return validation.ValidateStruct(s,
+func (s spec) Validate() error {
+	return validation.ValidateStruct(&s,
 		validation.Field(&s.Query, validation.Required, is.DNSName),
 		validation.Field(&s.Resolver, validation.Required, is.DialString),
 		validation.Field(&s.Tries, validation.Required),

--- a/checkers/http_2xx/spec.go
+++ b/checkers/http_2xx/spec.go
@@ -1,10 +1,10 @@
 package http_2xx
 
 import (
-	"github.com/teran/anycastd/config"
-
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
+
+	"github.com/teran/anycastd/config"
 )
 
 type spec struct {
@@ -15,8 +15,8 @@ type spec struct {
 	Timeout  config.Duration `json:"timeout"`
 }
 
-func (s *spec) Validate() error {
-	return validation.ValidateStruct(s,
+func (s spec) Validate() error {
+	return validation.ValidateStruct(&s,
 		validation.Field(&s.URL, validation.Required, is.URL),
 		validation.Field(&s.Method, validation.Required),
 		validation.Field(&s.Tries, validation.Required),


### PR DESCRIPTION
In the need of running struct field validators using `Validate()` method on pointers will no work silently. So this fix makes them working.

Unfortunately there's no option to cover that case except in tests by validating negative scenarios.