### PR TITLE
Move host configuration under static section for icmp_ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ services:
           ipv4: 33.22.11.0
       - kind: icmp_ping
         spec:
-          host: google.com
+          static:
+            host: google.com
           tries: 3
           interval: 100ms
           timeout: 5s

--- a/checkers/icmp_ping/icmp_ping.go
+++ b/checkers/icmp_ping/icmp_ping.go
@@ -128,7 +128,7 @@ func newWithPinger(
 	pingerFn func(host string, tries uint8, interval, timeout time.Duration) (*pingStats, error),
 ) (checkers.Checker, error) {
 	return &icmp_ping{
-		host:     s.Host,
+		host:     s.Static.Host,
 		tries:    s.Tries,
 		interval: time.Duration(s.Interval),
 		timeout:  time.Duration(s.Timeout),

--- a/checkers/icmp_ping/icmp_ping_test.go
+++ b/checkers/icmp_ping/icmp_ping_test.go
@@ -14,7 +14,7 @@ func TestCheck(t *testing.T) {
 
 	c, err := newWithPinger(
 		spec{
-			Host:     "127.0.0.1",
+			Static:   Static{Host: "127.0.0.1"},
 			Tries:    10,
 			Interval: config.Duration(10 * time.Second),
 			Timeout:  config.Duration(30 * time.Second),

--- a/checkers/icmp_ping/spec.go
+++ b/checkers/icmp_ping/spec.go
@@ -7,8 +7,18 @@ import (
 	"github.com/teran/anycastd/config"
 )
 
+type Static struct {
+	Host string `json:"host"`
+}
+
+func (s Static) Validate() error {
+	return validation.ValidateStruct(&s,
+		validation.Field(&s.Host, validation.Required, is.Host),
+	)
+}
+
 type spec struct {
-	Host     string          `json:"host"`
+	Static   Static          `json:"static"`
 	Tries    uint8           `json:"tries"`
 	Interval config.Duration `json:"interval"`
 	Timeout  config.Duration `json:"timeout"`
@@ -16,7 +26,7 @@ type spec struct {
 
 func (s spec) Validate() error {
 	return validation.ValidateStruct(&s,
-		validation.Field(&s.Host, validation.Required, is.Host),
+		validation.Field(&s.Static, validation.Required),
 		validation.Field(&s.Tries, validation.Required),
 		validation.Field(&s.Interval, validation.Required),
 		validation.Field(&s.Timeout, validation.Required),

--- a/checkers/icmp_ping/spec_test.go
+++ b/checkers/icmp_ping/spec_test.go
@@ -20,7 +20,7 @@ func TestSpecValidation(t *testing.T) {
 		{
 			name: "valid spec w/ domain name",
 			in: spec{
-				Host:     "test.example.org",
+				Static:   Static{Host: "test.example.org"},
 				Tries:    10,
 				Interval: config.Duration(1 * time.Second),
 				Timeout:  config.Duration(2 * time.Second),
@@ -29,7 +29,7 @@ func TestSpecValidation(t *testing.T) {
 		{
 			name: "valid spec w/ IP address",
 			in: spec{
-				Host:     "127.0.0.1",
+				Static:   Static{Host: "127.0.0.1"},
 				Tries:    10,
 				Interval: config.Duration(1 * time.Second),
 				Timeout:  config.Duration(2 * time.Second),
@@ -39,7 +39,7 @@ func TestSpecValidation(t *testing.T) {
 			name: "empty spec",
 			in:   spec{},
 			expError: errors.New(
-				"host: cannot be blank; interval: cannot be blank; timeout: cannot be blank; tries: cannot be blank.",
+				"interval: cannot be blank; static: (host: cannot be blank.); timeout: cannot be blank; tries: cannot be blank.",
 			),
 		},
 	}


### PR DESCRIPTION
To allow dynamic host detection for ping separate its definition to static and dynamic right from the start